### PR TITLE
Maintainers: Full caimito support by GamerBoy1234294

### DIFF
--- a/mist.devices
+++ b/mist.devices
@@ -4,6 +4,9 @@ raphael
 akita
 husky
 shiba
+komodo
+caiman
+tokay
 haydn
 begonia
 cupid

--- a/mist.maintainers
+++ b/mist.maintainers
@@ -12,3 +12,4 @@ Mayur_U
 Libra420T
 Mufasa
 JNWSG
+GamerBoy1234294


### PR DESCRIPTION
Caimito series of devices includes komodo (Pixel 9 Pro XL), caiman (Pixel 9 Pro), and tokay (Pixel 9). Full support for these devices are being added by me, GamerBoy1234294 (A.K.A. Trijal08). This is the beginning of the journey!